### PR TITLE
Reduce scope of insert locking to unblock reads when inserts are throttled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ These are changes that will probably be included in the next release.
  
 ### Fixed
 
+ * Reduce scope of insert locking unblock reads when inserts are throttled 
+
 ### Changed
  
 ### Removed


### PR DESCRIPTION
Inserts are throttled when the inbound data rate exceeds the rate at which
data can be flushed to disk. Move the throttling outside the scope of the insert
lock so reads can proceed.