### PR TITLE
Support variable length keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 These are changes that will probably be included in the next release.
 
 ### Added
+
+ * Support variable length keys
  
 ### Fixed
-
 
 ### Changed
  
@@ -21,7 +22,7 @@ These are changes that will probably be included in the next release.
 
 ### Fixed
 
- * Reduce scope of insert locking unblock reads when inserts are throttled 
+ * Reduce scope of insert locking to unblock reads when inserts are throttled 
  * Fix bucket scanner not detecting EOF
 
 ## [v0.1.0] - 2020-11-18

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Gonudb shares the design ideals that motivated NuDB (but see Status below):
 
 Keys and values are stored sequentially in an append only data file. The data file begins with a
 header that contains characteristic information about the file such as the version of the encoding
-scheme, a datastore identifier, an application identifier and the size of the keys. Data records
-follow immediately on from the header. Each record comprises the size of the value, followed by
-the key, followed by the value data. The data file is considered to be immutable and there are no
-delete or mutate operations.
+scheme, a datastore identifier and an application identifier. Data records follow immediately on
+from the header. Each record comprises the size of the value, followed by the size of the key,
+followed by the key, followed by the value data. The data file is considered to be immutable and
+there are no delete or mutate operations.
 
 Inserts are buffered in memory and periodically committed to disk. Clients are throttled based on
 the rate at which data is flushed to disk. Values are immediately discoverable via their key and
@@ -96,7 +96,6 @@ High priority tasks include:
 
 Additional features under consideration:
 
- * Allow variable size keys.
  * Allow alternate hashing functions to be specified.
 
 ## Author

--- a/cmd/gonudbadmin/info.go
+++ b/cmd/gonudbadmin/info.go
@@ -70,7 +70,6 @@ func infoFile(path string) []kv {
 			{Key: "Version", Value: dh.Version},
 			{Key: "UID", Value: dh.UID},
 			{Key: "AppNum", Value: dh.AppNum},
-			{Key: "KeySize", Value: Bytes(dh.KeySize)},
 			{Key: "File size", Value: Bytes(fStat.Size())},
 		}
 	case string(internal.KeyFileHeaderType):
@@ -84,7 +83,6 @@ func infoFile(path string) []kv {
 			{Key: "Version", Value: kh.Version},
 			{Key: "UID", Value: kh.UID},
 			{Key: "AppNum", Value: kh.AppNum},
-			{Key: "KeySize", Value: Bytes(kh.KeySize)},
 			{Key: "Salt", Value: kh.Salt},
 			{Key: "Pepper", Value: kh.Pepper},
 			{Key: "BlockSize", Value: Bytes(kh.BlockSize)},
@@ -104,7 +102,6 @@ func infoFile(path string) []kv {
 			{Key: "Version", Value: lh.Version},
 			{Key: "UID", Value: lh.UID},
 			{Key: "AppNum", Value: lh.AppNum},
-			{Key: "KeySize", Value: Bytes(lh.KeySize)},
 			{Key: "Salt", Value: lh.Salt},
 			{Key: "Pepper", Value: lh.Pepper},
 			{Key: "BlockSize", Value: Bytes(lh.BlockSize)},

--- a/cmd/gonudbadmin/main.go
+++ b/cmd/gonudbadmin/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-logr/logr"
 	"github.com/iand/logfmtr"
 	"github.com/urfave/cli/v2"
 
@@ -38,11 +39,16 @@ var logLevelFlag = &cli.IntFlag{
 	Value:   0,
 }
 
+var logger = logr.Discard()
+
 func initLogging(cc *cli.Context) error {
-	logfmtr.SetVerbosity(cc.Int("log-level"))
-	loggerOpts := logfmtr.DefaultOptions()
-	loggerOpts.Humanize = true
-	loggerOpts.Colorize = true
-	logfmtr.UseOptions(loggerOpts)
+	if cc.IsSet("log-level") {
+		logfmtr.SetVerbosity(cc.Int("log-level"))
+		loggerOpts := logfmtr.DefaultOptions()
+		loggerOpts.Humanize = true
+		loggerOpts.Colorize = true
+		logfmtr.UseOptions(loggerOpts)
+		logger = logfmtr.NewNamed("gonudb")
+	}
 	return nil
 }

--- a/cmd/gonudbadmin/verify.go
+++ b/cmd/gonudbadmin/verify.go
@@ -3,8 +3,9 @@ package main
 import (
 	"os"
 
-	"github.com/iand/gonudb/internal"
 	"github.com/urfave/cli/v2"
+
+	"github.com/iand/gonudb/internal"
 )
 
 var verifyCommand = &cli.Command{
@@ -36,7 +37,7 @@ func verify(cc *cli.Context) error {
 	datPath := cc.Args().Get(0)
 	keyPath := cc.Args().Get(1)
 
-	info, err := internal.VerifyStore(datPath, keyPath)
+	info, err := internal.VerifyStore(datPath, keyPath, logger)
 	if err != nil {
 		return cli.Exit(err.Error(), 1)
 	}
@@ -58,6 +59,8 @@ func verify(cc *cli.Context) error {
 			{Key: "ValueCountTotal", Value: info.ValueCountTotal},
 			{Key: "ValueBytesInUse", Value: Bytes(info.ValueBytesInUse)},
 			{Key: "ValueBytesTotal", Value: Bytes(info.ValueBytesTotal)},
+			{Key: "RecordBytesInUse", Value: Bytes(info.RecordBytesInUse)},
+			{Key: "RecordBytesTotal", Value: Bytes(info.RecordBytesTotal)},
 			{Key: "SpillCountInUse", Value: info.SpillCountInUse},
 			{Key: "SpillCountTotal", Value: info.SpillCountTotal},
 			{Key: "SpillBytesInUse", Value: Bytes(info.SpillBytesInUse)},
@@ -73,7 +76,6 @@ func verify(cc *cli.Context) error {
 		label: "Key file",
 		rows: []kv{
 			{Key: "KeyFileSize", Value: Bytes(info.KeyFileSize)},
-			{Key: "KeySize", Value: Bytes(info.KeySize)},
 			{Key: "Salt", Value: info.Salt},
 			{Key: "Pepper", Value: info.Pepper},
 			{Key: "BlockSize", Value: Bytes(info.BlockSize)},

--- a/cmd/gonudbsample/gonudbsample.go
+++ b/cmd/gonudbsample/gonudbsample.go
@@ -79,7 +79,6 @@ func run(cc *cli.Context) error {
 		logPath,
 		1,
 		gonudb.NewSalt(),
-		8,
 		4096,
 		0.5,
 	)
@@ -102,7 +101,7 @@ func run(cc *cli.Context) error {
 
 	keys := make([]string, 500)
 	for i := range keys {
-		keys[i] = fmt.Sprintf("key%05d", i)
+		keys[i] = fmt.Sprintf("key%09d", i)
 	}
 
 	fmt.Printf("Inserting %d samples\n", len(keys))

--- a/internal/bucket_test.go
+++ b/internal/bucket_test.go
@@ -295,7 +295,7 @@ func TestBucketMaybeSpill(t *testing.T) {
 		}
 		tmpfile := filepath.Join(tmpdir, "empty")
 
-		if err := CreateDataFile(tmpfile, 5, 6, 8); err != nil {
+		if err := CreateDataFile(tmpfile, 5, 6); err != nil {
 			t.Fatalf("unexpected error creating data file: %v", err)
 		}
 
@@ -328,7 +328,7 @@ func TestBucketMaybeSpill(t *testing.T) {
 
 		tmpfile := filepath.Join(tmpdir, "half")
 
-		if err := CreateDataFile(tmpfile, 5, 6, 8); err != nil {
+		if err := CreateDataFile(tmpfile, 5, 6); err != nil {
 			t.Fatalf("unexpected error creating data file: %v", err)
 		}
 
@@ -362,7 +362,7 @@ func TestBucketMaybeSpill(t *testing.T) {
 
 		tmpfile := filepath.Join(tmpdir, "full")
 
-		if err := CreateDataFile(tmpfile, 5, 6, 8); err != nil {
+		if err := CreateDataFile(tmpfile, 5, 6); err != nil {
 			t.Fatalf("unexpected error creating data file: %v", err)
 		}
 
@@ -413,7 +413,7 @@ func TestBucketMaybeSpill(t *testing.T) {
 
 		tmpfile := filepath.Join(tmpdir, "read")
 
-		if err := CreateDataFile(tmpfile, 5, 6, 8); err != nil {
+		if err := CreateDataFile(tmpfile, 5, 6); err != nil {
 			t.Fatalf("unexpected error creating data file: %v", err)
 		}
 

--- a/internal/error.go
+++ b/internal/error.go
@@ -20,9 +20,11 @@ var (
 	ErrInvalidSpill       = errors.New("not a spill record: missing spill marker")
 	ErrKeyExists          = errors.New("key exists")
 	ErrKeyMismatch        = errors.New("key mismatch")
+	ErrKeyMissing         = errors.New("key missing")
 	ErrKeyNotFound        = errors.New("key not found")
 	ErrKeySizeMismatch    = errors.New("key size mismatch")
-	ErrKeyWrongSize       = errors.New("key wrong size")
+	ErrKeyTooLarge        = errors.New("key too large")
+	ErrKeyWrongSize       = errors.New("key wrong size") // deprecated: use ErrKeyMissing and ErrKeyTooLarge instead
 	ErrNotDataFile        = errors.New("not a data file")
 	ErrNotKeyFile         = errors.New("not a key file")
 	ErrNotLogFile         = errors.New("not a log file")

--- a/internal/field.go
+++ b/internal/field.go
@@ -13,6 +13,10 @@ const (
 	MaxUint64 = math.MaxUint64
 
 	MaxInt16 = math.MaxInt16
+
+	MaxBlockSize = MaxUint16 // maximum length of a keyfile block in bytes (must not be larger than MaxKeySize due to on-disk representation)
+	MaxKeySize   = MaxUint16 // maximum length of a data record's key in bytes
+	MaxDataSize  = MaxUint48 // maximum length of a data record's value in bytes
 )
 
 const (

--- a/internal/file_test.go
+++ b/internal/file_test.go
@@ -16,7 +16,7 @@ func TestCreateKeyFile(t *testing.T) {
 	const blockSize = 256
 
 	filename := tmpdir + "key"
-	err = CreateKeyFile(filename, 121212, 222222, 32, 333333, blockSize, 0.7)
+	err = CreateKeyFile(filename, 121212, 222222, 333333, blockSize, 0.7)
 	if err != nil {
 		t.Errorf("CreateKeyFile: unexpected error: %v", err)
 	}

--- a/store.go
+++ b/store.go
@@ -10,8 +10,8 @@ import (
 	"github.com/iand/gonudb/internal"
 )
 
-func CreateStore(datPath, keyPath, logPath string, appnum, salt uint64, keySize, blockSize int, loadFactor float64) error {
-	return internal.CreateStore(datPath, keyPath, logPath, appnum, internal.NewUID(), salt, keySize, blockSize, loadFactor)
+func CreateStore(datPath, keyPath, logPath string, appnum, salt uint64, blockSize int, loadFactor float64) error {
+	return internal.CreateStore(datPath, keyPath, logPath, appnum, internal.NewUID(), salt, blockSize, loadFactor)
 }
 
 func OpenStore(datPath, keyPath, logPath string, options *StoreOptions) (*Store, error) {
@@ -308,9 +308,11 @@ var (
 	ErrInvalidSpill       = internal.ErrInvalidSpill
 	ErrKeyExists          = internal.ErrKeyExists
 	ErrKeyMismatch        = internal.ErrKeyMismatch
+	ErrKeyMissing         = internal.ErrKeyMissing
 	ErrKeyNotFound        = internal.ErrKeyNotFound
 	ErrKeySizeMismatch    = internal.ErrKeySizeMismatch
-	ErrKeyWrongSize       = internal.ErrKeyWrongSize
+	ErrKeyTooLarge        = internal.ErrKeyTooLarge
+	ErrKeyWrongSize       = internal.ErrKeyWrongSize // deprecated: use ErrKeyMissing and ErrKeyTooLarge instead
 	ErrNotDataFile        = internal.ErrNotDataFile
 	ErrNotKeyFile         = internal.ErrNotKeyFile
 	ErrNotLogFile         = internal.ErrNotLogFile


### PR DESCRIPTION
Previosuly key length was a property of the data file. Records in the data file
stored the key in this fixed number of bytes after the data length marker.

This change removes the limitation of fixed length keys. Data records now
store the key length for each record in two bytes immediately after the data
length marker.